### PR TITLE
Fix the wrong returned values after 360EntSecGroup-Skylar upgrade

### DIFF
--- a/backends/excel/excel_test.go
+++ b/backends/excel/excel_test.go
@@ -41,7 +41,10 @@ func checkProduct(t *testing.T, filename string) {
 	if activeSheetIndex == 0 && excelFile.SheetCount > 0 {
 		activeSheetIndex = 1
 	}
-	params := excelFile.GetRows(excelFile.GetSheetName(activeSheetIndex))
+	params, err := excelFile.GetRows(excelFile.GetSheetName(activeSheetIndex))
+	if err != nil {
+		t.Errorf("Failed to call the GetRows method, get error %v", err)
+	}
 
 	if len(params) == 0 {
 		t.Errorf("No products found in the templates")

--- a/backends/excel/reader.go
+++ b/backends/excel/reader.go
@@ -34,7 +34,10 @@ func (excel *Excel) NewReader(res *exchange.Resource, context *qor.Context) (exc
 			return nil, err
 		}
 
-		rows.records = reader.GetRows(sheetName)
+		rows.records, err = reader.GetRows(sheetName)
+		if err != nil {
+			return nil, err
+		}
 
 		for i, r := range rows.records {
 			for j, v := range r {


### PR DESCRIPTION
Fix following issue:

> # github.com/qor/exchange/backends/excel
> ../../../qor/exchange/backends/excel/reader.go:37:32: multiple-value reader.GetRows() in single-value context